### PR TITLE
Use OpticFor_ to fix typescript type error

### DIFF
--- a/__tests__/focus-lens.test.tsx
+++ b/__tests__/focus-lens.test.tsx
@@ -11,7 +11,7 @@ const succ = (input: number) => input + 1
 
 it('basic derivation using focus works', async () => {
   const bigAtom = atom({ a: 0 })
-  const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
+  const focusFunction = (optic: O.OpticFor_<{ a: number }>) => optic.prop('a')
 
   const Counter = () => {
     const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
@@ -50,7 +50,7 @@ it('basic derivation using focus works', async () => {
 
 it('focus on an atom works', async () => {
   const bigAtom = atom({ a: 0 })
-  const focusFunction = (optic: O.OpticFor<{ a: number }>) => optic.prop('a')
+  const focusFunction = (optic: O.OpticFor_<{ a: number }>) => optic.prop('a')
 
   const Counter = () => {
     const [count, setCount] = useAtom(focusAtom(bigAtom, focusFunction))
@@ -139,7 +139,7 @@ it('focus on async atom works', async () => {
       set(baseAtom, next)
     }
   )
-  const focusFunction = (optic: O.OpticFor<{ count: number }>) =>
+  const focusFunction = (optic: O.OpticFor_<{ count: number }>) =>
     optic.prop('count')
 
   const Counter = () => {

--- a/__tests__/focus-prism.test.tsx
+++ b/__tests__/focus-prism.test.tsx
@@ -9,7 +9,7 @@ import { focusAtom } from '../src/index'
 
 it('updates prisms', async () => {
   const bigAtom = atom<{ a?: number }>({ a: 5 })
-  const focusFunction = (optic: O.OpticFor<{ a?: number }>) =>
+  const focusFunction = (optic: O.OpticFor_<{ a?: number }>) =>
     optic.prop('a').optional()
 
   const Counter = () => {
@@ -40,7 +40,7 @@ it('updates prisms', async () => {
 
 it('atoms that focus on no values are not updated', async () => {
   const bigAtom = atom<{ a?: number }>({})
-  const focusFunction = (optic: O.OpticFor<{ a?: number }>) =>
+  const focusFunction = (optic: O.OpticFor_<{ a?: number }>) =>
     optic.prop('a').optional()
 
   const Counter = () => {

--- a/__tests__/focus-traversal.test.tsx
+++ b/__tests__/focus-traversal.test.tsx
@@ -9,7 +9,7 @@ import { focusAtom } from '../src/index'
 
 it('updates traversals', async () => {
   const bigAtom = atom<{ a?: number }[]>([{ a: 5 }, {}, { a: 6 }])
-  const focusFunction = (optic: O.OpticFor<{ a?: number }[]>) =>
+  const focusFunction = (optic: O.OpticFor_<{ a?: number }[]>) =>
     optic.elems().prop('a').optional()
 
   const Counter = () => {

--- a/examples/01_typescript/src/App.tsx
+++ b/examples/01_typescript/src/App.tsx
@@ -4,7 +4,7 @@ import { atom } from 'jotai/vanilla'
 import type { PrimitiveAtom } from 'jotai/vanilla'
 import { splitAtom } from 'jotai/vanilla/utils'
 import { focusAtom } from 'jotai-optics'
-import { OpticFor } from 'optics-ts'
+import { OpticFor_ } from 'optics-ts'
 
 // Use splitAtom and focusAtom to interactive with fast food price
 const basicFoodList = [
@@ -50,7 +50,7 @@ const useFocusAtom = (anAtom: PrimitiveAtom<Food>) => {
   return useSetAtom(
     focusAtom(
       anAtom,
-      useCallback((optic: OpticFor<Food>) => optic.prop('amount'), [])
+      useCallback((optic: OpticFor_<Food>) => optic.prop('amount'), [])
     )
   )
 }

--- a/src/focusAtom.ts
+++ b/src/focusAtom.ts
@@ -19,18 +19,18 @@ type NonFunction<T> = [T] extends [(...args: any[]) => any] ? never : T
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S>, [Promise<S>], R>,
-  callback: (optic: O.OpticFor<S>) => O.Prism<S, any, A>
+  callback: (optic: O.OpticFor_<S>) => O.Prism<S, any, A>
 ): WritableAtom<Promise<A | undefined>, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S>, [Promise<S>], R>,
-  callback: (optic: O.OpticFor<S>) => O.Traversal<S, any, A>
+  callback: (optic: O.OpticFor_<S>) => O.Traversal<S, any, A>
 ): WritableAtom<Promise<A[]>, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S>, [Promise<S>], R>,
   callback: (
-    optic: O.OpticFor<S>
+    optic: O.OpticFor_<S>
   ) => O.Lens<S, any, A> | O.Equivalence<S, any, A> | O.Iso<S, any, A>
 ): WritableAtom<Promise<A>, [SetStateAction<A>], R>
 
@@ -38,18 +38,18 @@ export function focusAtom<S, A, R>(
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S | undefined>, [Promise<S>], R>,
-  callback: (optic: O.OpticFor<S | undefined>) => O.Prism<S, any, A>
+  callback: (optic: O.OpticFor_<S | undefined>) => O.Prism<S, any, A>
 ): WritableAtom<Promise<A | undefined>, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S | undefined>, [Promise<S>], R>,
-  callback: (optic: O.OpticFor<S | undefined>) => O.Traversal<S, any, A>
+  callback: (optic: O.OpticFor_<S | undefined>) => O.Traversal<S, any, A>
 ): WritableAtom<Promise<A[]>, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<Promise<S | undefined>, [Promise<S>], R>,
   callback: (
-    optic: O.OpticFor<S | undefined>
+    optic: O.OpticFor_<S | undefined>
   ) => O.Lens<S, any, A> | O.Equivalence<S, any, A> | O.Iso<S, any, A>
 ): WritableAtom<Promise<A>, [SetStateAction<A>], R>
 
@@ -57,18 +57,18 @@ export function focusAtom<S, A, R>(
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S, [NonFunction<S>], R>,
-  callback: (optic: O.OpticFor<S>) => O.Prism<S, any, A>
+  callback: (optic: O.OpticFor_<S>) => O.Prism<S, any, A>
 ): WritableAtom<A | undefined, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S, [NonFunction<S>], R>,
-  callback: (optic: O.OpticFor<S>) => O.Traversal<S, any, A>
+  callback: (optic: O.OpticFor_<S>) => O.Traversal<S, any, A>
 ): WritableAtom<A[], [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S, [NonFunction<S>], R>,
   callback: (
-    optic: O.OpticFor<S>
+    optic: O.OpticFor_<S>
   ) => O.Lens<S, any, A> | O.Equivalence<S, any, A> | O.Iso<S, any, A>
 ): WritableAtom<A, [SetStateAction<A>], R>
 
@@ -76,18 +76,18 @@ export function focusAtom<S, A, R>(
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S | undefined, [NonFunction<S>], R>,
-  callback: (optic: O.OpticFor<S | undefined>) => O.Prism<S, any, A>
+  callback: (optic: O.OpticFor_<S | undefined>) => O.Prism<S, any, A>
 ): WritableAtom<A | undefined, [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S | undefined, [NonFunction<S>], R>,
-  callback: (optic: O.OpticFor<S | undefined>) => O.Traversal<S, any, A>
+  callback: (optic: O.OpticFor_<S | undefined>) => O.Traversal<S, any, A>
 ): WritableAtom<A[], [SetStateAction<A>], R>
 
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S | undefined, [NonFunction<S>], R>,
   callback: (
-    optic: O.OpticFor<S | undefined>
+    optic: O.OpticFor_<S | undefined>
   ) => O.Lens<S, any, A> | O.Equivalence<S, any, A> | O.Iso<S, any, A>
 ): WritableAtom<A, [SetStateAction<A>], R>
 
@@ -96,7 +96,7 @@ export function focusAtom<S, A, R>(
 export function focusAtom<S, A, R>(
   baseAtom: WritableAtom<S, [NonFunction<S>], R>,
   callback: (
-    optic: O.OpticFor<S>
+    optic: O.OpticFor_<S>
   ) =>
     | O.Lens<S, any, A>
     | O.Equivalence<S, any, A>


### PR DESCRIPTION
Fixes `Type instantiation is excessively deep and possibly infinite` error when using TypeScript 5.1.x.

Fixes #9