### PR TITLE
fix: remove `exports["."].module` to be compatible with resolution policy of nodejs offical & bundlers like `vite`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/index.modern.mjs",
-      "module": "./dist/index.modern.js",
       "default": "./dist/index.umd.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/src/index.d.ts",
-      "module": "./dist/index.modern.js",
+      "module": "./dist/index.modern.mjs",
       "import": "./dist/index.modern.mjs",
       "default": "./dist/index.umd.js"
     }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/src/index.d.ts",
-      "module": "./dist/index.modern.mjs",
       "import": "./dist/index.modern.mjs",
+      "module": "./dist/index.modern.js",
       "default": "./dist/index.umd.js"
     }
   },


### PR DESCRIPTION
some build tools like `vite` would fail if type of package is not explicit declared while file extension is `.js`:

<img width="1366" alt="image" src="https://github.com/jotaijs/jotai-optics/assets/4919405/4fd05d20-4b9a-4a16-98c2-c2255645aa82">

@dai-shi please help review, thanks